### PR TITLE
Fix uninitialized hus on pressure levels

### DIFF
--- a/inc/version_decl
+++ b/inc/version_decl
@@ -1,1 +1,1 @@
-   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.5.1'
+   CHARACTER (LEN=*), PARAMETER :: release_version = 'V4.5.1.6 (CWC)'

--- a/phys/module_diag_pld.F
+++ b/phys/module_diag_pld.F
@@ -82,6 +82,7 @@ CONTAINS
                ght_pl(i,kp,j) = missing
                s_pl  (i,kp,j) = missing
                td_pl (i,kp,j) = missing
+               q_pl  (i,kp,j) = missing
             END DO
          END DO
       END DO

--- a/phys/module_diag_zld.F
+++ b/phys/module_diag_zld.F
@@ -82,6 +82,7 @@ CONTAINS
                ght_zl(i,kz,j) = missing
                s_zl  (i,kz,j) = missing
                td_zl (i,kz,j) = missing
+               q_zl  (i,kz,j) = missing
                p_zl  (i,kz,j) = missing
             END DO
          END DO


### PR DESCRIPTION
Specific humidity on low pressure levels (especially hus1000) has a funny behaviour on low pressure areas:
![hus1000bug](https://github.com/user-attachments/assets/b3c22fe2-3ea8-4b75-84e0-4871720c33d8)

It seems that, instead assigning a NaN where surface pressure is below 1000 hPa, this variable is assigned its latest valid value (or zero if it never had one).